### PR TITLE
Add README and documentation maintenance rule

### DIFF
--- a/ENGINEERING.md
+++ b/ENGINEERING.md
@@ -93,3 +93,15 @@
       - _release/_: These branches are used to prepare for a new production release. They allow for last-minute dotting of i’s and crossing t’s. Use the prefix release/. For example, release/v1.0.1.
       - _docs/_: These branches are used to write, update, or fix documentation eg. the README.md file. For instance, docs/api-endpoints.
     - Branch names (after the prefix) should start with the issue number, and then contain a 1-to-3 word descriptive name, lowercase, with hyphens betwen them. For example, 27-fix-avatar-size.
+
+## Documentation
+
+15. **README maintenance**:
+    - Update README.md when changes affect:
+      - Project setup or prerequisites
+      - Available npm scripts
+      - Tech stack (major version bumps or new tools)
+      - Project structure (new top-level directories or key files)
+      - Data model or variant system behavior
+    - Keep the tech stack section current with package.json
+    - No update needed for internal refactors, patch versions, or minor feature work

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# Resume
+
+Online, responsive, interactive resume with flatfile-based data-driven content and the ability to export digital copies in PDF format.
+
+## Tech Stack
+
+| Category | Technology |
+|---|---|
+| Framework | SvelteKit + Svelte 5 (static adapter) |
+| Styling | Tailwind CSS 4 |
+| Language | TypeScript (strict mode) |
+| Testing | Vitest + Testing Library |
+| PDF Export | Puppeteer |
+| Build Tool | Vite |
+
+## Getting Started
+
+**Prerequisites:** Node.js 24+, npm
+
+```sh
+git clone https://github.com/kaecyra/resume.git
+cd resume
+npm install
+```
+
+## Development
+
+| Script | Description |
+|---|---|
+| `npm run dev` | Start development server |
+| `npm run build` | Build for production (static site) |
+| `npm run preview` | Preview production build |
+| `npm run check` | Run svelte-check type checking |
+| `npm test` | Run tests once |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm run test:coverage` | Run tests with coverage report |
+| `npm run generate-pdf` | Generate PDF from built site using Puppeteer |
+| `npm run prepare` | Sync SvelteKit types |
+
+## Project Structure
+
+```
+data/
+  resume.yaml             # All resume content
+  variants/               # Variant manifests for tailored output
+    default.yaml
+src/
+  lib/
+    data.ts               # Data loading and variant resolution
+    types.ts              # TypeScript type definitions
+  routes/                 # SvelteKit pages
+scripts/
+  generate-pdf.ts         # Puppeteer-based PDF generation
+```
+
+## Data Model
+
+Resume content lives in `data/resume.yaml` as a single source of truth containing all skills, employment history, languages, and courses. Variant manifests in `data/variants/` select and order a subset of this content for a specific role or audience, enabling multiple tailored resumes from one data source.
+
+## CI
+
+GitHub Actions runs on pull requests to `main`, executing type checking, tests, and a production build in sequence. See [ENGINEERING.md](./ENGINEERING.md) for full coding standards and CI requirements.
+
+## Project Documentation
+
+- [ENGINEERING.md](./ENGINEERING.md) - Coding standards and project conventions
+- [WORKING_AGREEMENT.md](./WORKING_AGREEMENT.md) - Collaboration workflow and task management
+- [LESSONS.md](./LESSONS.md) - Lessons learned and corrective patterns


### PR DESCRIPTION
## Summary

- Add comprehensive README with tech stack, setup instructions, development scripts, project structure, data model overview, and CI information
- Add rule 15 to ENGINEERING.md establishing README maintenance guidelines so documentation stays current as the project evolves

Closes #12

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all npm script names match package.json
- [ ] Confirm ENGINEERING.md rule numbering is sequential (rule 15 follows rule 14)
- [ ] CI passes (type check, tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)