### PR TITLE
Add classic theme with full resume rendering

### DIFF
--- a/data/variants/default.yaml
+++ b/data/variants/default.yaml
@@ -1,3 +1,5 @@
+theme: "classic"
+
 title: "Chief Technology Officer"
 
 summary: |

--- a/src/app.css
+++ b/src/app.css
@@ -1,1 +1,8 @@
 @import "tailwindcss";
+
+@media print {
+  * {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}

--- a/src/lib/data.test.ts
+++ b/src/lib/data.test.ts
@@ -39,6 +39,7 @@ describe("load_variant", () => {
   it("loads and parses the default variant", () => {
     const variant = load_variant("default");
 
+    expect(variant.theme).toBe("classic");
     expect(variant.title).toBeDefined();
     expect(variant.summary).toBeDefined();
     expect(variant.skills).toBeInstanceOf(Array);
@@ -54,6 +55,7 @@ describe("resolve_resume", () => {
     const variant = load_variant("default");
     const resolved = resolve_resume(data, variant);
 
+    expect(resolved.theme).toBe(variant.theme);
     expect(resolved.profile.name).toBe("Tim Gunter");
     expect(resolved.title).toBe(variant.title);
     expect(resolved.summary).toBe(variant.summary);
@@ -80,6 +82,7 @@ describe("resolve_resume", () => {
   it("skips unknown ids without error", () => {
     const data = load_resume_data();
     const variant: Parameters<typeof resolve_resume>[1] = {
+      theme: "classic",
       title: "Test",
       summary: "Test summary",
       skills: ["nonexistent", "strategy"],

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -35,6 +35,7 @@ export function resolve_resume(data: ResumeData, variant: VariantManifest): Reso
     .filter((c): c is NonNullable<typeof c> => c !== undefined);
 
   return {
+    theme: variant.theme,
     profile: data.profile,
     title: variant.title,
     summary: variant.summary,

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,43 @@
+import { format_bold, format_date, format_date_range } from "./format.js";
+
+describe("format_bold", () => {
+  it("converts **text** to <strong>text</strong>", () => {
+    expect(format_bold("Led **high-performing teams** to success")).toBe(
+      "Led <strong>high-performing teams</strong> to success"
+    );
+  });
+
+  it("handles multiple bold segments", () => {
+    expect(format_bold("**one** and **two**")).toBe(
+      "<strong>one</strong> and <strong>two</strong>"
+    );
+  });
+
+  it("returns text unchanged when no bold markers present", () => {
+    expect(format_bold("plain text")).toBe("plain text");
+  });
+});
+
+describe("format_date", () => {
+  it("formats YYYY-MM to Mon YYYY", () => {
+    expect(format_date("2024-07")).toBe("Jul 2024");
+  });
+
+  it("formats January correctly", () => {
+    expect(format_date("2020-01")).toBe("Jan 2020");
+  });
+
+  it("formats December correctly", () => {
+    expect(format_date("2019-12")).toBe("Dec 2019");
+  });
+});
+
+describe("format_date_range", () => {
+  it("formats a range with both dates", () => {
+    expect(format_date_range("2022-02", "2024-07")).toBe("Feb 2022 - Jul 2024");
+  });
+
+  it("uses Present when end is null", () => {
+    expect(format_date_range("2024-07", null)).toBe("Jul 2024 - Present");
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,20 @@
+const MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+export function format_bold(text: string): string {
+  return text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+}
+
+export function format_date(date_str: string): string {
+  const [year, month] = date_str.split("-");
+  const month_index = parseInt(month, 10) - 1;
+  return `${MONTHS[month_index]} ${year}`;
+}
+
+export function format_date_range(start: string, end: string | null): string {
+  const start_formatted = format_date(start);
+  const end_formatted = end ? format_date(end) : "Present";
+  return `${start_formatted} - ${end_formatted}`;
+}

--- a/src/lib/themes/classic/ClassicCourses.svelte
+++ b/src/lib/themes/classic/ClassicCourses.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Course } from "$lib/types.js";
+  import { format_date } from "$lib/format.js";
+
+  let { courses }: { courses: Course[] } = $props();
+</script>
+
+<section class="mb-6">
+  <h2 class="mb-3 text-lg font-semibold uppercase tracking-wide text-gray-700 border-b border-gray-200 pb-1">
+    Certifications
+  </h2>
+  <div class="space-y-1">
+    {#each courses as course}
+      <div class="flex items-baseline justify-between text-sm">
+        <span class="text-gray-700">
+          {course.title}
+          <span class="text-gray-400">- {course.institution}</span>
+        </span>
+        <span class="shrink-0 text-gray-500">{format_date(course.date)}</span>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/themes/classic/ClassicEmployment.svelte
+++ b/src/lib/themes/classic/ClassicEmployment.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { Employment } from "$lib/types.js";
+
+  import ClassicEmploymentEntry from "./ClassicEmploymentEntry.svelte";
+
+  let { employment }: { employment: Employment[] } = $props();
+</script>
+
+<section class="mb-6">
+  <h2 class="mb-3 text-lg font-semibold uppercase tracking-wide text-gray-700 border-b border-gray-200 pb-1">
+    Experience
+  </h2>
+  {#each employment as entry}
+    <ClassicEmploymentEntry {entry} />
+  {/each}
+</section>

--- a/src/lib/themes/classic/ClassicEmploymentEntry.svelte
+++ b/src/lib/themes/classic/ClassicEmploymentEntry.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import type { Employment } from "$lib/types.js";
+  import { format_bold, format_date_range } from "$lib/format.js";
+
+  let { entry }: { entry: Employment } = $props();
+
+  const date_range = $derived(format_date_range(entry.start_date, entry.end_date));
+</script>
+
+<div class="mb-4 print:break-inside-avoid">
+  <div class="flex items-baseline justify-between">
+    <div>
+      <h3 class="text-base font-semibold text-gray-900">{entry.title}</h3>
+      <p class="text-sm text-gray-600">
+        {entry.company}{#if entry.location}, {entry.location}{/if}
+      </p>
+    </div>
+    <span class="shrink-0 text-sm text-gray-500">{date_range}</span>
+  </div>
+
+  {#if entry.description}
+    <p class="mt-2 text-sm leading-relaxed text-gray-600 italic">{entry.description.trim()}</p>
+  {/if}
+
+  {#if entry.summary}
+    <p class="mt-2 text-sm leading-relaxed text-gray-700">{entry.summary.trim()}</p>
+  {/if}
+
+  {#if entry.highlights.length > 0}
+    <ul class="mt-2 list-disc space-y-1 pl-5">
+      {#each entry.highlights as highlight}
+        <li class="text-sm leading-relaxed text-gray-700">
+          {#if highlight.title}
+            <span class="font-medium">{highlight.title}:</span>
+          {/if}
+          {@html format_bold(highlight.description.trim())}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/src/lib/themes/classic/ClassicHeader.svelte
+++ b/src/lib/themes/classic/ClassicHeader.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { Profile } from "$lib/types.js";
+
+  let { profile, title }: { profile: Profile; title: string } = $props();
+</script>
+
+<header class="mb-6 border-b border-gray-300 pb-6">
+  <h1 class="text-4xl font-bold tracking-tight text-gray-900">{profile.name}</h1>
+  <p class="mt-1 text-xl text-gray-500">{title}</p>
+  <div class="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-600">
+    <span>{profile.contact.email}</span>
+    <span>{profile.contact.phone}</span>
+    <span>{profile.contact.address}</span>
+  </div>
+</header>

--- a/src/lib/themes/classic/ClassicLanguages.svelte
+++ b/src/lib/themes/classic/ClassicLanguages.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { Language } from "$lib/types.js";
+
+  let { languages }: { languages: Language[] } = $props();
+</script>
+
+<section class="mb-6">
+  <h2 class="mb-3 text-lg font-semibold uppercase tracking-wide text-gray-700 border-b border-gray-200 pb-1">
+    Languages
+  </h2>
+  <div class="flex flex-wrap gap-x-8 gap-y-1">
+    {#each languages as language}
+      <span class="text-sm text-gray-700">
+        {language.name}
+        <span class="text-gray-400">({language.proficiency})</span>
+      </span>
+    {/each}
+  </div>
+</section>

--- a/src/lib/themes/classic/ClassicSkills.svelte
+++ b/src/lib/themes/classic/ClassicSkills.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Skill } from "$lib/types.js";
+
+  let { skills }: { skills: Skill[] } = $props();
+
+  const MAX_LEVEL = 5;
+</script>
+
+<section class="mb-6">
+  <h2 class="mb-3 text-lg font-semibold uppercase tracking-wide text-gray-700 border-b border-gray-200 pb-1">
+    Skills
+  </h2>
+  <div class="grid grid-cols-2 gap-x-8 gap-y-2">
+    {#each skills as skill}
+      <div class="flex items-center justify-between">
+        <span class="text-sm text-gray-700">{skill.name}</span>
+        <div class="flex gap-1">
+          {#each Array(MAX_LEVEL) as _, i}
+            <span
+              class="inline-block h-2 w-2 rounded-full {i < skill.level ? 'bg-gray-700' : 'bg-gray-200'}"
+            ></span>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/themes/classic/ClassicSummary.svelte
+++ b/src/lib/themes/classic/ClassicSummary.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  let { summary }: { summary: string } = $props();
+
+  const paragraphs = $derived(summary.split("\n\n").filter((p) => p.trim()));
+</script>
+
+<section class="mb-6">
+  <h2 class="mb-3 text-lg font-semibold uppercase tracking-wide text-gray-700 border-b border-gray-200 pb-1">
+    Summary
+  </h2>
+  {#each paragraphs as paragraph}
+    <p class="mt-2 text-sm leading-relaxed text-gray-700">{paragraph.trim()}</p>
+  {/each}
+</section>

--- a/src/lib/themes/classic/ClassicTheme.svelte
+++ b/src/lib/themes/classic/ClassicTheme.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { ResolvedResume } from "$lib/types.js";
+
+  import ClassicHeader from "./ClassicHeader.svelte";
+  import ClassicSummary from "./ClassicSummary.svelte";
+  import ClassicSkills from "./ClassicSkills.svelte";
+  import ClassicEmployment from "./ClassicEmployment.svelte";
+  import ClassicLanguages from "./ClassicLanguages.svelte";
+  import ClassicCourses from "./ClassicCourses.svelte";
+
+  let { resume }: { resume: ResolvedResume } = $props();
+</script>
+
+<div class="mx-auto max-w-4xl p-8 text-gray-800 print:max-w-none print:p-0">
+  <ClassicHeader profile={resume.profile} title={resume.title} />
+  <ClassicSummary summary={resume.summary} />
+  <ClassicSkills skills={resume.skills} />
+  <ClassicEmployment employment={resume.employment} />
+  <ClassicLanguages languages={resume.languages} />
+  <ClassicCourses courses={resume.courses} />
+</div>

--- a/src/lib/themes/index.test.ts
+++ b/src/lib/themes/index.test.ts
@@ -1,0 +1,12 @@
+import { get_theme } from "./index.js";
+
+describe("get_theme", () => {
+  it("returns a component for classic", () => {
+    const theme = get_theme("classic");
+    expect(theme).toBeDefined();
+  });
+
+  it("throws for unknown theme name", () => {
+    expect(() => get_theme("nonexistent")).toThrow('Unknown theme: "nonexistent"');
+  });
+});

--- a/src/lib/themes/index.ts
+++ b/src/lib/themes/index.ts
@@ -1,0 +1,20 @@
+import type { Component } from "svelte";
+import type { ResolvedResume } from "$lib/types.js";
+
+import ClassicTheme from "./classic/ClassicTheme.svelte";
+
+interface ThemeProps {
+  resume: ResolvedResume;
+}
+
+const THEMES: Record<string, Component<ThemeProps>> = {
+  classic: ClassicTheme,
+};
+
+export function get_theme(name: string): Component<ThemeProps> {
+  const theme = THEMES[name];
+  if (!theme) {
+    throw new Error(`Unknown theme: "${name}"`);
+  }
+  return theme;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,6 +56,7 @@ export interface ResumeData {
 }
 
 export interface VariantManifest {
+  theme: string;
   title: string;
   summary: string;
   skills: string[];
@@ -65,6 +66,7 @@ export interface VariantManifest {
 }
 
 export interface ResolvedResume {
+  theme: string;
   profile: Profile;
   title: string;
   summary: string;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
+  import { get_theme } from "$lib/themes/index.js";
+
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
+
+  const Theme = $derived(get_theme(data.resume.theme));
 </script>
 
 <svelte:head>
   <title>{data.resume.profile.name} - {data.resume.title}</title>
 </svelte:head>
 
-<main class="mx-auto max-w-3xl p-8">
-  <h1 class="text-3xl font-bold">{data.resume.profile.name}</h1>
-  <p class="text-xl text-gray-600">{data.resume.title}</p>
-</main>
+<Theme resume={data.resume} />


### PR DESCRIPTION
## Summary

- Adds theme infrastructure with build-time theme selection via the variant manifest (`theme` field on `VariantManifest` and `ResolvedResume`)
- Implements a "classic" theme with 8 Svelte components rendering all resume sections: header, summary, skills (with dot-level indicators), experience (with bold highlights via `{@html}`), languages, and certifications
- Adds formatting utilities (`format_bold`, `format_date`, `format_date_range`) and print-friendly CSS

Closes #15
Closes #11

## Test plan

- [ ] Run `npm test` -- 19 tests pass (data, format, theme registry, smoke)
- [ ] Run `npm run check` -- 0 errors, 0 warnings
- [ ] Run dev server and visually inspect all sections render correctly
- [ ] Run `npm run build && npm run preview` then `npm run generate-pdf` -- verify PDF output contains all sections with no awkward page breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)