### PR TITLE
Add custom styled error page

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { page } from "$app/stores";
+</script>
+
+<div class="flex min-h-screen items-center justify-center bg-gray-100">
+  <div class="text-center">
+    <h1 class="text-8xl font-bold tracking-tight text-gray-900">
+      {$page.status}
+    </h1>
+    <p class="mt-4 text-xl text-gray-500">
+      {$page.error?.message}
+    </p>
+    <a
+      href="/"
+      class="mt-8 inline-block text-sm text-gray-600 underline hover:text-gray-900"
+    >
+      Back to home
+    </a>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Add `src/routes/+error.svelte` with a clean, centered error page using the classic theme's gray palette
- Shows HTTP status code, error message, and a link back to home
- No layout-level changes; resume pages are completely unaffected

Closes #19

## Test plan
- [ ] `npm run check` passes with no errors
- [ ] `npm run build` completes successfully
- [ ] `/` renders the resume unchanged
- [ ] `/nonexistent` shows the custom styled 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)