### PR TITLE
Commit shared Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(.venv/bin/*)",
+      "Bash(source:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(uv:*)",
+      "Bash(pytest:*)",
+      "Bash(alembic:*)",
+      "Bash(docker:*)",
+      "Bash(docker-compose:*)",
+      "Bash(docker compose:*)",
+      "Bash(curl:*)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(file:*)",
+      "Bash(mkdir:*)",
+      "Bash(ps:*)",
+      "Bash(pgrep:*)",
+      "Bash(pkill:*)",
+      "Bash(lsof:*)",
+      "Bash(chmod:*)",
+      "WebSearch"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ coverage/
 
 # Claude
 tasks/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Commit `.claude/settings.json` (shared team permissions config) to version control
- Add `.claude/settings.local.json` to `.gitignore` (personal/machine-specific overrides)

This follows Anthropic's official recommendation: `settings.json` is team-shared and should be committed, while `settings.local.json` is personal and should not.

Closes #18

## Test plan
- [ ] `.claude/settings.json` is tracked in git
- [ ] `.claude/settings.local.json` is gitignored
- [ ] Existing gitignore rules still work (tasks/, .env, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)