### PR TITLE
Add product-manual theme

### DIFF
--- a/data/variants/cto.yaml
+++ b/data/variants/cto.yaml
@@ -1,0 +1,44 @@
+theme: "product-manual"
+
+title: "Chief Technology Officer"
+
+summary: |
+    Seasoned technology leader and systems-thinking CTO with a deep background in
+    software architecture and operations. I've led engineering organizations of
+    approximately 300 people, delivered multi-team eight-figure engagements, and
+    scaled a SaaS business from $0 to $10M ARR that culminated in acquisition.
+
+    I combine strategic vision with hands-on technical ownership and a product-led
+    mindset--driving automation, observability, multi-cloud resilience, customer
+    obsession and people-first cultures that increase delivery velocity while
+    reducing operational cost and human toil.
+
+    I am a force of nature when surrounded by other leaders with a shared vision
+    and focused on a goal I believe in.
+
+skills:
+    - strategy
+    - culture
+    - operational_innovation
+    - customer_experience
+    - executive_leadership
+    - communication
+    - software_engineering
+    - solution_architecture
+
+employment:
+    - monks-vpe
+    - monks-doe
+    - higher-logic
+    - vanilla-coo
+    - vanilla-vpo
+    - vanilla-doo
+
+languages:
+    - english
+    - engineer
+    - french
+
+courses:
+    - csm
+    - cspo

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
 @import "tailwindcss";
 
 @media print {

--- a/src/lib/themes/index.test.ts
+++ b/src/lib/themes/index.test.ts
@@ -6,6 +6,11 @@ describe("get_theme", () => {
     expect(theme).toBeDefined();
   });
 
+  it("returns a component for product-manual", () => {
+    const theme = get_theme("product-manual");
+    expect(theme).toBeDefined();
+  });
+
   it("throws for unknown theme name", () => {
     expect(() => get_theme("nonexistent")).toThrow('Unknown theme: "nonexistent"');
   });

--- a/src/lib/themes/index.ts
+++ b/src/lib/themes/index.ts
@@ -2,6 +2,7 @@ import type { Component } from "svelte";
 import type { ResolvedResume } from "$lib/types.js";
 
 import ClassicTheme from "./classic/ClassicTheme.svelte";
+import ManualTheme from "./product-manual/ManualTheme.svelte";
 
 interface ThemeProps {
   resume: ResolvedResume;
@@ -9,6 +10,7 @@ interface ThemeProps {
 
 const THEMES: Record<string, Component<ThemeProps>> = {
   classic: ClassicTheme,
+  "product-manual": ManualTheme,
 };
 
 export function get_theme(name: string): Component<ThemeProps> {

--- a/src/lib/themes/product-manual/ManualCourses.svelte
+++ b/src/lib/themes/product-manual/ManualCourses.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Course } from "$lib/types.js";
+  import { format_date } from "$lib/format.js";
+
+  let { courses }: { courses: Course[] } = $props();
+</script>
+
+<section class="mb-6">
+  <div class="mb-3 border-b border-stone-300 pb-1">
+    <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-stone-400">
+      Certifications:
+    </h2>
+  </div>
+  <div class="space-y-2">
+    {#each courses as course}
+      <div class="border-b border-dotted border-stone-300 pb-1">
+        <div class="flex items-baseline justify-between">
+          <span class="text-xs text-stone-700">{course.title}</span>
+          <span class="shrink-0 text-[10px] text-stone-400">{format_date(course.date)}</span>
+        </div>
+        <span class="text-[10px] uppercase tracking-wider text-stone-400">
+          {course.institution}
+        </span>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/themes/product-manual/ManualEmployment.svelte
+++ b/src/lib/themes/product-manual/ManualEmployment.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { Employment } from "$lib/types.js";
+
+  import ManualEmploymentEntry from "./ManualEmploymentEntry.svelte";
+
+  let { employment }: { employment: Employment[] } = $props();
+</script>
+
+<section class="mb-6">
+  <div class="mb-4 border-b border-stone-300 pb-1">
+    <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-stone-400">
+      Project Files
+    </h2>
+  </div>
+  {#each employment as entry}
+    <ManualEmploymentEntry {entry} />
+  {/each}
+</section>

--- a/src/lib/themes/product-manual/ManualEmploymentEntry.svelte
+++ b/src/lib/themes/product-manual/ManualEmploymentEntry.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { Employment } from "$lib/types.js";
+  import { format_bold, format_date_range } from "$lib/format.js";
+
+  let { entry }: { entry: Employment } = $props();
+
+  const date_range = $derived(format_date_range(entry.start_date, entry.end_date));
+</script>
+
+<div class="mb-5 border border-stone-300 bg-[#f8f4ed] p-4 print:break-inside-avoid">
+  <div class="flex items-start justify-between gap-4">
+    <div class="min-w-0">
+      <div class="flex items-baseline gap-2 border-b border-stone-300 pb-1">
+        <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Role</span>
+        <h3 class="font-sans text-sm font-bold uppercase tracking-wide text-stone-800">
+          {entry.title}
+        </h3>
+      </div>
+      <div class="mt-2 flex items-baseline gap-2 border-b border-stone-300 pb-1">
+        <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Org</span>
+        <span class="text-xs text-stone-600">
+          {entry.company}{#if entry.location}
+            <span class="text-stone-400"> // {entry.location}</span>
+          {/if}
+        </span>
+      </div>
+    </div>
+    <div class="shrink-0 border-b border-stone-300 pb-1">
+      <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Period</span>
+      <p class="text-xs text-stone-600">{date_range}</p>
+    </div>
+  </div>
+
+  {#if entry.description}
+    <p class="mt-3 text-[11px] italic leading-relaxed text-stone-500">
+      {entry.description.trim()}
+    </p>
+  {/if}
+
+  {#if entry.summary}
+    <p class="mt-2 text-xs leading-relaxed text-stone-700">{entry.summary.trim()}</p>
+  {/if}
+
+  {#if entry.highlights.length > 0}
+    <ul class="mt-3 space-y-1.5 border-t border-dashed border-stone-300 pt-3">
+      {#each entry.highlights as highlight}
+        <li class="flex items-start gap-2 text-xs leading-relaxed text-stone-700">
+          <span class="mt-1 inline-block h-1.5 w-1.5 shrink-0 rotate-45 bg-[#c4412b]"></span>
+          <span>
+            {#if highlight.title}
+              <span class="font-bold uppercase text-stone-500">{highlight.title}:</span>
+            {/if}
+            {@html format_bold(highlight.description.trim())}
+          </span>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/src/lib/themes/product-manual/ManualHeader.svelte
+++ b/src/lib/themes/product-manual/ManualHeader.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import type { Profile } from "$lib/types.js";
+
+  let { profile, title }: { profile: Profile; title: string } = $props();
+</script>
+
+<header>
+  <div class="bg-[#c4412b] px-8 py-3">
+    <span class="font-sans text-2xl font-bold uppercase tracking-[0.25em] text-white">
+      Technical
+    </span>
+  </div>
+  <div class="bg-[#3d3d3d] px-8 py-1">
+    <span class="font-sans text-[10px] uppercase tracking-[0.3em] text-stone-400">
+      Specifications
+    </span>
+  </div>
+
+  <div class="px-8 pt-6 pb-4">
+    <p class="text-[10px] uppercase tracking-[0.2em] text-stone-400">
+      Technical Specifications:
+    </p>
+    <h1 class="mt-1 font-sans text-xl font-bold uppercase tracking-wide text-stone-800">
+      {profile.name}
+      <span class="mx-1 text-stone-400">|</span>
+      <span class="text-stone-600">{title}</span>
+    </h1>
+
+    <div class="mt-3 flex items-center gap-3">
+      <span
+        class="inline-block bg-[#3d3d3d] px-2.5 py-0.5 font-sans text-[9px] font-bold uppercase tracking-[0.2em] text-[#f5f0e8]"
+      >
+        Status: Deployed
+      </span>
+    </div>
+
+    <div class="mt-5 grid grid-cols-3 gap-x-6 gap-y-2 border-t border-stone-300 pt-4">
+      <div class="border-b border-stone-300 pb-1.5">
+        <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Loc</span>
+        <p class="mt-0.5 text-xs text-stone-700">{profile.contact.address}</p>
+      </div>
+      <div class="border-b border-stone-300 pb-1.5">
+        <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Aph</span>
+        <p class="mt-0.5 text-xs text-stone-700">{profile.contact.phone}</p>
+      </div>
+      <div class="border-b border-stone-300 pb-1.5">
+        <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Sig</span>
+        <p class="mt-0.5 text-xs text-stone-700">{profile.contact.email}</p>
+      </div>
+    </div>
+  </div>
+</header>

--- a/src/lib/themes/product-manual/ManualLanguages.svelte
+++ b/src/lib/themes/product-manual/ManualLanguages.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Language } from "$lib/types.js";
+
+  let { languages }: { languages: Language[] } = $props();
+</script>
+
+<section class="mb-6">
+  <div class="mb-3 border-b border-stone-300 pb-1">
+    <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-stone-400">
+      Communication Protocols:
+    </h2>
+  </div>
+  <div class="space-y-2">
+    {#each languages as language}
+      <div class="flex items-baseline justify-between border-b border-dotted border-stone-300 pb-1">
+        <span class="text-xs text-stone-700">{language.name}</span>
+        <span class="text-[10px] uppercase tracking-wider text-stone-400">
+          {language.proficiency}
+        </span>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/themes/product-manual/ManualSkills.svelte
+++ b/src/lib/themes/product-manual/ManualSkills.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import type { Skill } from "$lib/types.js";
+
+  let { skills }: { skills: Skill[] } = $props();
+
+  const STAMP_STYLES = [
+    { border: "#2a7b88", text: "#2a7b88", bg: "rgba(42, 123, 136, 0.07)" },
+    { border: "#c4412b", text: "#c4412b", bg: "rgba(196, 65, 43, 0.07)" },
+    { border: "#d4822b", text: "#d4822b", bg: "rgba(212, 130, 43, 0.07)" },
+  ];
+
+  const ROTATIONS = [-4, 3, -2, 5, -3, 2, -5, 4];
+
+  function get_stamp_style(index: number): string {
+    const color = STAMP_STYLES[index % STAMP_STYLES.length];
+    const rotation = ROTATIONS[index % ROTATIONS.length];
+    return [
+      `border-color: ${color.border}`,
+      `color: ${color.text}`,
+      `background-color: ${color.bg}`,
+      `transform: rotate(${rotation}deg)`,
+    ].join("; ");
+  }
+
+  function get_dot_color(index: number, filled: boolean): string {
+    if (!filled) return "background-color: rgba(0, 0, 0, 0.12)";
+    return `background-color: ${STAMP_STYLES[index % STAMP_STYLES.length].border}`;
+  }
+
+  const MAX_LEVEL = 5;
+</script>
+
+<section class="mb-6">
+  <div class="mb-4 border-b border-stone-300 pb-1">
+    <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-stone-400">
+      Protocol: Proficiency
+    </h2>
+  </div>
+  <div class="flex flex-wrap justify-center gap-5">
+    {#each skills as skill, i}
+      <div
+        class="flex h-[5.5rem] w-[5.5rem] flex-col items-center justify-center rounded-full border-[3px] text-center"
+        style={get_stamp_style(i)}
+      >
+        <span class="px-1 text-[8px] font-bold uppercase leading-tight">{skill.name}</span>
+        <div class="mt-1 flex gap-[3px]">
+          {#each Array(MAX_LEVEL) as _, j}
+            <span
+              class="inline-block h-[5px] w-[5px] rounded-full"
+              style={get_dot_color(i, j < skill.level)}
+            ></span>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/themes/product-manual/ManualSummary.svelte
+++ b/src/lib/themes/product-manual/ManualSummary.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  let { summary }: { summary: string } = $props();
+
+  const paragraphs = $derived(summary.split("\n\n").filter((p) => p.trim()));
+</script>
+
+<section class="mb-6">
+  <div class="mb-3 border-b border-stone-300 pb-1">
+    <h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-stone-400">
+      Technical Overview:
+    </h2>
+  </div>
+  {#each paragraphs as paragraph}
+    <p class="mt-2 text-xs leading-relaxed text-stone-700">{paragraph.trim()}</p>
+  {/each}
+</section>

--- a/src/lib/themes/product-manual/ManualTheme.svelte
+++ b/src/lib/themes/product-manual/ManualTheme.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { ResolvedResume } from "$lib/types.js";
+
+  import ManualHeader from "./ManualHeader.svelte";
+  import ManualSummary from "./ManualSummary.svelte";
+  import ManualSkills from "./ManualSkills.svelte";
+  import ManualEmployment from "./ManualEmployment.svelte";
+  import ManualLanguages from "./ManualLanguages.svelte";
+  import ManualCourses from "./ManualCourses.svelte";
+
+  let { resume }: { resume: ResolvedResume } = $props();
+</script>
+
+<div class="min-h-screen bg-[#8a9aa4] py-10 print:min-h-0 print:bg-white print:py-0">
+  <div
+    class="mx-auto max-w-4xl border border-[#c5bfb3] bg-[#f5f0e8] shadow-xl print:max-w-none print:border-none print:shadow-none"
+    style="font-family: 'Share Tech Mono', ui-monospace, monospace;"
+  >
+    <ManualHeader profile={resume.profile} title={resume.title} />
+    <div class="px-8 pb-8">
+      <ManualSummary summary={resume.summary} />
+      <ManualSkills skills={resume.skills} />
+      <ManualEmployment employment={resume.employment} />
+      <div class="grid grid-cols-2 gap-8 print:grid-cols-2">
+        <ManualLanguages languages={resume.languages} />
+        <ManualCourses courses={resume.courses} />
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Implements new "product-manual" theme inspired by 80s technical specification sheets with orange-red banner, cream paper background, circular rubber-stamp skill badges, and form-field styled sections
- Adds Share Tech Mono Google Font for typewriter body text aesthetic
- Creates `/cto` variant route for viewing the new theme

## Test plan

- [ ] Visual review of `/cto` route against reference image aesthetic
- [ ] Print preview (Cmd+P) for print styling
- [ ] Verify `/` (classic theme) is unaffected
- [ ] All tests pass (`npm run test` - 22 tests including new theme registry test)
- [ ] Production build succeeds (`npm run build`)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)