### PR TITLE
Fix cross-platform build and restrict UFW to LAN

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,13 +18,10 @@ done
 
 IMAGE="ghcr.io/kaecyra/resume:latest"
 
-echo "Building Docker image..."
-docker compose build
-
 echo "Logging in to GHCR..."
 echo "${GHCR_PAT}" | docker login ghcr.io -u kaecyra --password-stdin
 
-echo "Pushing image to GHCR..."
-docker push "${IMAGE}"
+echo "Building and pushing Docker image (linux/amd64)..."
+docker buildx build --platform linux/amd64 -t "${IMAGE}" --push .
 
 echo "Image pushed. Watchtower on the VM will detect and deploy the update."

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -87,11 +87,11 @@ echo ""
 echo "--- Firewall (UFW) ---"
 apt-get install -y ufw
 
-ufw allow OpenSSH
-ufw allow 3000/tcp
+ufw allow from 192.168.0.0/16 to any app OpenSSH
+ufw allow from 192.168.0.0/16 to any port 3000 proto tcp
 ufw --force enable
 
-echo "Firewall configured: OpenSSH and port 3000/tcp allowed."
+echo "Firewall configured: OpenSSH and port 3000/tcp allowed (LAN only)."
 echo ""
 
 # -- Docker installation -------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `deploy.sh` to use `docker buildx --platform linux/amd64` so manual deploys from ARM Macs produce correct images for the x86_64 VM
- Restrict UFW rules in `setup-host.sh` to `192.168.0.0/16` (LAN only)

## Test plan

- [x] Manual deploy from ARM Mac produces working container on x86_64 VM
- [x] Container starts and serves on port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)