### PR TITLE
Tag Docker images with CalVer version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Read version
+        id: version
+        run: echo "value=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -27,6 +31,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.value }}
             type=sha,prefix=sha-,format=short
 
       - uses: docker/build-push-action@v6

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,12 +16,21 @@ for var in "${REQUIRED_VARS[@]}"; do
     fi
 done
 
-IMAGE="ghcr.io/kaecyra/resume:latest"
+IMAGE="ghcr.io/kaecyra/resume"
+
+if [[ ! -f VERSION ]]; then
+    echo "Error: VERSION file not found. Run from the repository root." >&2
+    exit 1
+fi
+VERSION=$(cat VERSION)
 
 echo "Logging in to GHCR..."
 echo "${GHCR_PAT}" | docker login ghcr.io -u kaecyra --password-stdin
 
-echo "Building and pushing Docker image (linux/amd64)..."
-docker buildx build --platform linux/amd64 -t "${IMAGE}" --push .
+echo "Building and pushing Docker image (linux/amd64) version ${VERSION}..."
+docker buildx build --platform linux/amd64 \
+    -t "${IMAGE}:latest" \
+    -t "${IMAGE}:${VERSION}" \
+    --push .
 
 echo "Image pushed. Watchtower on the VM will detect and deploy the update."


### PR DESCRIPTION
## Summary

- Deploy workflow reads VERSION file and adds it as an image tag (e.g. `ghcr.io/kaecyra/resume:2026.02.10`)
- Manual deploy script (`deploy.sh`) applies both `latest` and version tags
- SHA-based tags retained for traceability
- `latest` tag preserved (Watchtower depends on it)

## Test plan

- [x] `bash -n scripts/deploy.sh` passes syntax check
- [ ] Push to main produces image with all three tags in GHCR

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)