### PR TITLE
Inject version into site and PDF output

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="@sveltejs/kit" />
 
+declare const __APP_VERSION__: string;
+
 declare namespace App {
   // interface Error {}
   // interface Locals {}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,3 +5,7 @@
 </script>
 
 {@render children()}
+
+<footer class="py-2 text-center text-xs text-gray-400 print:hidden">
+  v{__APP_VERSION__}
+</footer>

--- a/src/routes/[[variant=variant]]/+page.svelte
+++ b/src/routes/[[variant=variant]]/+page.svelte
@@ -10,6 +10,7 @@
 
 <svelte:head>
   <title>{data.resume.profile.name} - {data.resume.title}</title>
+  <meta name="version" content={__APP_VERSION__} />
 </svelte:head>
 
 <Theme resume={data.resume} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
+import { readFileSync } from "node:fs";
 import tailwindcss from "@tailwindcss/vite";
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vitest/config";
 
+const version = readFileSync("VERSION", "utf-8").trim();
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   plugins: [tailwindcss(), sveltekit()],
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

- Read VERSION file at build time via Vite `define` (`__APP_VERSION__`)
- Add `<meta name="version">` tag for machine-readable version
- Add subtle footer with version (hidden in print via `print:hidden`)
- PDF output captures the meta tag since Puppeteer renders the full HTML

## Test plan

- [x] `npm run check` passes (0 errors, 0 warnings)
- [x] `npm test` passes (22 tests)
- [x] `npm run build` succeeds
- [x] Built HTML contains `<meta name="version" content="2026.02.10">`
- [x] Built HTML contains version footer text

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)