### PR TITLE
Fix healthcheck to use 127.0.0.1 instead of localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "3000:80"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:80/"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:80/"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -222,7 +222,7 @@ services:
       - "3000:80"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:80/"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:80/"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

- Change healthcheck URL from `http://localhost:80/` to `http://127.0.0.1:80/` in both `docker-compose.yml` and `setup-host.sh`
- Alpine resolves `localhost` to `::1` (IPv6) first, but nginx only binds IPv4, causing "Connection refused"

## Test plan

- [ ] Update `/opt/resume/docker-compose.yml` on VM, restart, confirm container reports healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)