### PR TITLE
Fix PDF download: generate PDFs during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:24-alpine AS build
 
+# Chromium for Puppeteer PDF generation
+RUN apk add --no-cache chromium nss freetype harfbuzz ca-certificates ttf-freefont
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -7,6 +12,9 @@ RUN npm ci
 
 COPY . .
 RUN npm run build
+
+# Generate PDFs: start preview server, run Puppeteer, stop server
+RUN (npm run preview &) && sleep 2 && npm run generate-pdf
 
 FROM nginx:stable-alpine
 

--- a/scripts/generate-pdf.ts
+++ b/scripts/generate-pdf.ts
@@ -7,7 +7,10 @@ const BASE_URL = process.env.BASE_URL ?? "http://localhost:4173";
 
 async function generate_pdf(): Promise<void> {
   const variants = list_variants();
-  const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
 
   try {
     for (const variant of variants) {


### PR DESCRIPTION
## Summary
- Install Chromium in the Docker build stage so Puppeteer can generate PDFs after the site build
- Add `--no-sandbox` args to `puppeteer.launch()` for Alpine/Docker compatibility
- PDFs are served as static files by nginx at `/{variant}.pdf` (e.g. `/cto.pdf`)

## Details
The `generate-pdf.ts` script existed but was never run in the build pipeline, so PDFs weren't included in the Docker image. This adds a build step that starts the Vite preview server, runs Puppeteer to generate PDFs into the `build/` directory, then the multi-stage build copies them into the nginx image alongside the HTML.

Chromium and its dependencies stay in the discarded build stage -- the final nginx image size is unchanged.

## Test plan
- [x] `npm run check` -- 0 errors, 0 warnings
- [x] `npm test` -- 22/22 tests pass
- [x] `docker build` -- both `cto.pdf` and `default.pdf` generated
- [x] `curl -I http://localhost:3099/cto.pdf` -- 200 OK, `Content-Type: application/pdf`
- [x] `curl -I http://localhost:3099/default.pdf` -- 200 OK, `Content-Type: application/pdf`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)