### PR TITLE
Add domain expertise, tagline, and print CSS for CTO positioning

### DIFF
--- a/data/resume.yaml
+++ b/data/resume.yaml
@@ -2,7 +2,7 @@ profile:
   name: "Tim Gunter"
   photo: "assets/headshot-illustration.png"
   contact:
-    address: "REDACTED"
+    location: "Montreal, QC"
     phone: "REDACTED"
     email: "REDACTED"
     linkedin: "linkedin.com/in/guntertim"
@@ -39,6 +39,28 @@ skills:
   - id: solution_architecture
     name: "Solution Architecture"
     level: 5
+
+domains:
+  - id: organizational-cultural-engineering
+    title: "Organizational & Cultural Engineering"
+    description: |
+      Built high-trust, high-autonomy engineering cultures in high-volatility environments. Leveraged radical transparency and data-driven alignment to bolster talent retention during corporate restructuring and acquisitions.
+  - id: infrastructure-fiscal-sovereignty
+    title: "Infrastructure & Fiscal Sovereignty"
+    description: |
+      Expert in cloud architecture, data sovereignty and cloud repatriation, hardware-level optimization, and cost containment. Specialized in reclaiming fiscal leverage from public cloud providers by maximizing hardware utilization and implementing comprehensive IaC/automation.
+  - id: product-led-strategy
+    title: "Product-Led Technical Strategy"
+    description: |
+      Proven track record of identifying and productizing repeatable technical assets within service-based P&Ls. Experienced in navigating the "Build vs. Buy" landscape to ensure technical investment aligns with long-term business value.
+  - id: systemic-modernization
+    title: "Systemic Modernization"
+    description: |
+      Refactored legacy "artisanal" manual environments into versioned, automated, and horizontally scalable architectures. Expert at identifying and neutralizing "single-point-of-failure" technical debt that threatens business continuity.
+  - id: narrative-translation
+    title: "Narrative & Technical Translation"
+    description: |
+      Skilled at distilling complex architectural diagrams and technical risks into succinct, actionable insights for non-technical stakeholders, board members, and clients.
 
 employment:
   - id: monks-vpe

--- a/data/variants/cto-a.yaml
+++ b/data/variants/cto-a.yaml
@@ -1,0 +1,47 @@
+theme: "retro-technical"
+
+title: "Chief Technology Officer"
+
+summary: |
+  High-integrity technical leader and operator who builds the systems—technical and organizational—that make high-performance 
+  delivery inevitable. Expert in unit economics and radical transparency, specializing in de-risking technical debt and 
+  aligning architecture with the P&L to ensure velocity translates to margin. Proven track record of productizing innovation 
+  and stabilizing engineering organizations through extreme volatility.
+
+tagline: |
+  **I provide the technical leadership required to scale without the bullshit.** I'm a force of nature when aligned with a 
+  shared vision and a goal worth achieving.
+
+domains:
+  - organizational-cultural-engineering
+  - infrastructure-fiscal-sovereignty
+  - product-led-strategy
+  - systemic-modernization
+  - narrative-translation
+
+skills:
+  - strategy
+  - culture
+  - operational_innovation
+  - customer_experience
+  - executive_leadership
+  - communication
+  - software_engineering
+  - solution_architecture
+
+employment:
+  - monks-vpe
+  - monks-doe
+  - higher-logic
+  - vanilla-coo
+  - vanilla-vpo
+  - vanilla-doo
+
+languages:
+  - english
+  - engineer
+  - french
+
+courses:
+  - csm
+  - cspo

--- a/data/variants/cto-b.yaml
+++ b/data/variants/cto-b.yaml
@@ -13,8 +13,16 @@ summary: |
   obsession and people-first cultures that increase delivery velocity while
   reducing operational cost and human toil.
 
+tagline: |
   **I am a force of nature** when surrounded by other leaders with a shared vision
   and when focused on a goal I believe in.
+
+domains:
+  - organizational-cultural-engineering
+  - infrastructure-fiscal-sovereignty
+  - product-led-strategy
+  - systemic-modernization
+  - narrative-translation
 
 skills:
   - strategy

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -38,6 +38,10 @@ export function resolve_resume(data: ResumeData, variant: VariantManifest): Reso
     .map((id) => data.languages.find((l) => l.id === id))
     .filter((l): l is NonNullable<typeof l> => l !== undefined);
 
+  const domains = (variant.domains ?? [])
+    .map((id) => data.domains.find((d) => d.id === id))
+    .filter((d): d is NonNullable<typeof d> => d !== undefined);
+
   const courses = variant.courses
     .map((id) => data.courses.find((c) => c.id === id))
     .filter((c): c is NonNullable<typeof c> => c !== undefined);
@@ -47,7 +51,9 @@ export function resolve_resume(data: ResumeData, variant: VariantManifest): Reso
     profile: data.profile,
     title: variant.title,
     summary: variant.summary,
+    tagline: variant.tagline,
     skills,
+    domains,
     employment,
     languages,
     courses,

--- a/src/lib/themes/classic/ClassicHeader.svelte
+++ b/src/lib/themes/classic/ClassicHeader.svelte
@@ -10,6 +10,6 @@
   <div class="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-600">
     <span>{profile.contact.email}</span>
     <span>{profile.contact.phone}</span>
-    <span>{profile.contact.address}</span>
+    <span>{profile.contact.location}</span>
   </div>
 </header>

--- a/src/lib/themes/product-manual/ManualHeader.svelte
+++ b/src/lib/themes/product-manual/ManualHeader.svelte
@@ -37,7 +37,7 @@
     <div class="mt-5 grid grid-cols-3 gap-x-6 gap-y-2 border-t border-stone-300 pt-4">
       <div class="border-b border-stone-300 pb-1.5">
         <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Loc</span>
-        <p class="mt-0.5 text-xs text-stone-700">{profile.contact.address}</p>
+        <p class="mt-0.5 text-xs text-stone-700">{profile.contact.location}</p>
       </div>
       <div class="border-b border-stone-300 pb-1.5">
         <span class="text-[9px] font-bold uppercase tracking-[0.15em] text-stone-400">Aph</span>

--- a/src/lib/themes/retro-technical/RetroCourses.svelte
+++ b/src/lib/themes/retro-technical/RetroCourses.svelte
@@ -11,7 +11,7 @@
   }
 </style>
 
-<section class="bg-[#1a2744] p-5">
+<section class="bg-[#1a2744] p-5 print:break-inside-avoid">
   <div class="mb-1">
     <span class="text-[11px] uppercase tracking-[0.2em] text-[#8b9bb5]">Section {section}</span>
     <h2 class="mt-1 text-base font-semibold uppercase tracking-[0.15em] text-[#e87a2e]">

--- a/src/lib/themes/retro-technical/RetroDomains.svelte
+++ b/src/lib/themes/retro-technical/RetroDomains.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import type { Domain } from "$lib/types.js";
+
+  let { domains, section }: { domains: Domain[]; section: string } = $props();
+</script>
+
+<style>
+  h2 {
+    font-family: var(--retro-heading-font);
+  }
+</style>
+
+<section>
+  <div class="mb-4 print:break-after-avoid">
+    <span class="text-[11px] uppercase tracking-[0.2em] text-[#a07850]">
+      <span class="italic">[chp. {section}]</span>
+    </span>
+    <h2 class="mt-1 text-xl font-semibold uppercase tracking-[0.15em] text-[#e87a2e]">
+      Functional Subsystems
+    </h2>
+    <div class="mt-1 h-[2px] w-16 bg-[#e87a2e]"></div>
+  </div>
+
+  <div class="flex flex-col gap-3">
+    {#each domains as domain}
+      <div class="print:break-inside-avoid">
+        <h3 class="text-base font-semibold uppercase tracking-[0.15em] text-[#c96620]" style="font-family: var(--retro-heading-font);">
+          {domain.title}
+        </h3>
+        <p class="mt-1 text-sm leading-relaxed text-[#1a2744]">
+          {domain.description.trim()}
+        </p>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/themes/retro-technical/RetroEmployment.svelte
+++ b/src/lib/themes/retro-technical/RetroEmployment.svelte
@@ -13,7 +13,7 @@
 </style>
 
 <section>
-  <div class="mb-4">
+  <div class="mb-4 print:break-after-avoid">
     <span class="text-[11px] uppercase tracking-[0.2em] text-[#a07850]">
       <span class="italic">[chp. {section}]</span>
     </span>

--- a/src/lib/themes/retro-technical/RetroEmploymentEntry.svelte
+++ b/src/lib/themes/retro-technical/RetroEmploymentEntry.svelte
@@ -13,6 +13,7 @@
   h3 {
     font-family: var(--retro-heading-font);
   }
+
 </style>
 
 <div class="mb-4 bg-[#1a2744] p-4 md:p-5 print:p-5 print:[box-decoration-break:clone]">
@@ -67,11 +68,13 @@
   {#if entry.highlights.length > 0}
     <ul class="mt-3 space-y-1.5 border-t border-dashed border-[#243555] pt-3">
       {#each entry.highlights as highlight}
-        <li class="flex items-start gap-2 text-base leading-relaxed text-[#f0e6d6] print:break-inside-avoid">
-          <span class="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rotate-45 bg-[#e87a2e]"></span>
+        <li class="flex gap-2 text-base leading-relaxed text-[#f0e6d6] print:break-inside-avoid">
+          <span class="flex h-[1lh] shrink-0 items-center">
+            <span class="inline-block h-1.5 w-1.5 rotate-45 bg-[#e87a2e]"></span>
+          </span>
           <span>
             {#if highlight.title}
-              <span class="font-bold uppercase text-[#8b9bb5]">{highlight.title}:</span>
+              <span class="font-semibold uppercase text-[#8b9bb5]" style="font-family: var(--retro-heading-font);">{highlight.title}:</span>
             {/if}
             {@html format_bold(highlight.description.trim())}
           </span>

--- a/src/lib/themes/retro-technical/RetroHeader.svelte
+++ b/src/lib/themes/retro-technical/RetroHeader.svelte
@@ -10,7 +10,7 @@
   }
 </style>
 
-<section class="bg-[#1a2744] p-5">
+<section class="bg-[#1a2744] p-5 print:break-inside-avoid">
   <div class="mb-1">
     <span class="text-[11px] uppercase tracking-[0.2em] text-[#8b9bb5]">Section 1.1</span>
     <h2 class="mt-1 text-base font-semibold uppercase tracking-[0.15em] text-[#e87a2e]">
@@ -32,7 +32,7 @@
     <span class="text-[11px] font-bold uppercase tracking-[0.15em] text-[#8b9bb5]">
       Location
     </span>
-    <span class="text-base text-[#8b9bb5]">{profile.contact.address}</span>
+    <span class="text-base text-[#8b9bb5]">{profile.contact.location}</span>
 
     <span class="text-[11px] font-bold uppercase tracking-[0.15em] text-[#8b9bb5]">
       Signal

--- a/src/lib/themes/retro-technical/RetroLanguages.svelte
+++ b/src/lib/themes/retro-technical/RetroLanguages.svelte
@@ -10,7 +10,7 @@
   }
 </style>
 
-<section class="bg-[#1a2744] p-5">
+<section class="bg-[#1a2744] p-5 print:break-inside-avoid">
   <div class="mb-1">
     <span class="text-[11px] uppercase tracking-[0.2em] text-[#8b9bb5]">Section {section}</span>
     <h2 class="mt-1 text-base font-semibold uppercase tracking-[0.15em] text-[#e87a2e]">

--- a/src/lib/themes/retro-technical/RetroSkills.svelte
+++ b/src/lib/themes/retro-technical/RetroSkills.svelte
@@ -87,7 +87,7 @@
 </style>
 
 <section>
-  <div class="mb-4">
+  <div class="mb-4 print:break-after-avoid">
     <span class="text-[11px] uppercase tracking-[0.2em] text-[#a07850]">
       <span class="italic">[chp. {section}]</span>
     </span>
@@ -128,7 +128,7 @@
   </div>
 
   <!-- Exploded isometric parts diagram -->
-  <div class="mt-2">
+  <div class="mt-2 print:break-inside-avoid">
     
     <svg viewBox="0 35 500 190" class="w-full">
       <!-- explosion axis -->

--- a/src/lib/themes/retro-technical/RetroSummary.svelte
+++ b/src/lib/themes/retro-technical/RetroSummary.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { format_bold } from "$lib/format.js";
 
-  let { summary, section }: { summary: string; section: string } = $props();
+  let { summary, section, tagline }: { summary: string; section: string; tagline?: string } = $props();
 
   const paragraphs = $derived(summary.split("\n\n").filter((p) => p.trim()));
 </script>
@@ -12,8 +12,8 @@
   }
 </style>
 
-<section>
-  <div class="mb-4">
+<section class="print:break-inside-avoid">
+  <div class="mb-4 print:break-after-avoid">
     <span class="text-[11px] uppercase tracking-[0.2em] text-[#a07850]">
       <span class="italic">[chp. {section}]</span>
     </span>
@@ -26,4 +26,10 @@
   {#each paragraphs as paragraph}
     <p class="mt-2 first:mt-0 text-base leading-relaxed text-[#1a2744]">{@html format_bold(paragraph.trim())}</p>
   {/each}
+
+  {#if tagline}
+    <div class="mt-4 border-t border-[#c96620]/30 pt-3">
+      <p class="text-base leading-relaxed text-[#1a2744]/80">{@html format_bold(tagline.trim())}</p>
+    </div>
+  {/if}
 </section>

--- a/src/lib/themes/retro-technical/RetroTheme.svelte
+++ b/src/lib/themes/retro-technical/RetroTheme.svelte
@@ -2,7 +2,7 @@
   import type { ResolvedResume } from "$lib/types.js";
 
   import RetroSummary from "./RetroSummary.svelte";
-  import RetroSkills from "./RetroSkills.svelte";
+  import RetroDomains from "./RetroDomains.svelte";
   import RetroEmployment from "./RetroEmployment.svelte";
   import RetroLanguages from "./RetroLanguages.svelte";
   import RetroCourses from "./RetroCourses.svelte";
@@ -85,12 +85,12 @@
 
     <!-- Summary - full width -->
     <div class="bg-[#faf9f7] p-4 md:p-6 print:p-6">
-      <RetroSummary summary={resume.summary} section="1" />
+      <RetroSummary summary={resume.summary} section="1" tagline={resume.tagline} />
     </div>
 
     <!-- Bottom row: skills left, languages+courses right -->
     <div class="grid grid-cols-1 gap-6 border-t-2 border-[#c96620] p-4 md:grid-cols-[60%_1fr] md:p-6 print:grid-cols-[60%_1fr] print:p-6">
-      <RetroSkills skills={resume.skills} section="2" />
+      <RetroDomains domains={resume.domains} section="2" />
       <div class="flex flex-col gap-4">
         <RetroLanguages languages={resume.languages} section="2.1" />
         <RetroCourses courses={resume.courses} section="2.2" />
@@ -110,7 +110,7 @@
         <span class="hidden text-[#e87a2e] md:inline">|</span>
         <span class="text-[#f0e6d6]">{resume.profile.contact.email}</span>
         <span class="hidden text-[#e87a2e] md:inline">|</span>
-        <span class="text-[#f0e6d6]">{resume.profile.contact.address}</span>
+        <span class="text-[#f0e6d6]">{resume.profile.contact.location}</span>
       </div>
     </div>
   </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 export interface Contact {
-  address: string;
+  location: string;
   phone: string;
   email: string;
   linkedin?: string;
@@ -48,9 +48,16 @@ export interface Course {
   date: string;
 }
 
+export interface Domain {
+  id: string;
+  title: string;
+  description: string;
+}
+
 export interface ResumeData {
   profile: Profile;
   skills: Skill[];
+  domains: Domain[];
   employment: Employment[];
   languages: Language[];
   courses: Course[];
@@ -60,7 +67,9 @@ export interface VariantManifest {
   theme: string;
   title: string;
   summary: string;
+  tagline?: string;
   skills: string[];
+  domains?: string[];
   employment: string[];
   languages: string[];
   courses: string[];
@@ -71,7 +80,9 @@ export interface ResolvedResume {
   profile: Profile;
   title: string;
   summary: string;
+  tagline?: string;
   skills: Skill[];
+  domains: Domain[];
   employment: Employment[];
   languages: Language[];
   courses: Course[];


### PR DESCRIPTION
## Summary
- Wire up `domains` (base data → types → variant selection → rendering) and `tagline` (variant → types → rendering) for CTO resume variants
- Replace `RetroSkills` with new `RetroDomains` component ("Functional Subsystems" section) in retro-technical theme
- Add print CSS break rules (`break-inside-avoid`, `break-after-avoid`) across retro-technical components
- Rename `Contact.address` to `Contact.location` across all themes
- Fix highlight bullet alignment using `h-[1lh]` unit instead of fragile `mt-*` offsets
- Switch highlight titles and domain titles to Rajdhani heading font
- Replace single `cto.yaml` variant with `cto-a` and `cto-b` variants

## Test plan
- [ ] `npm run build` passes clean (verified)
- [ ] Preview cto-a and cto-b variants in browser — domains render in left column, tagline appears below summary
- [ ] Default variant still renders correctly (tagline/domains are optional, gracefully absent)
- [ ] `npm run generate-pdf` produces PDFs without layout regressions
- [ ] Highlight bullets align with first line of text across all employment entries

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)