### PR TITLE
Replace homebrewed format_bold() with marked library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "resume",
       "version": "0.0.0",
       "dependencies": {
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.1.1",
+        "marked": "^17.0.2"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",
@@ -2978,6 +2979,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.2.tgz",
+      "integrity": "sha512-s5HZGFQea7Huv5zZcAGhJLT3qLpAfnY7v7GWkICUr0+Wd5TFEtdlRR2XUL5Gg+RH7u2Df595ifrxR03mBaw7gA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mitt": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "marked": "^17.0.2"
   }
 }

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,20 +1,38 @@
-import { format_bold, format_date, format_date_range } from "./format.js";
+import { format_markdown, format_date, format_date_range } from "./format.js";
 
-describe("format_bold", () => {
+describe("format_markdown", () => {
   it("converts **text** to <strong>text</strong>", () => {
-    expect(format_bold("Led **high-performing teams** to success")).toBe(
+    expect(format_markdown("Led **high-performing teams** to success")).toBe(
       "Led <strong>high-performing teams</strong> to success"
     );
   });
 
   it("handles multiple bold segments", () => {
-    expect(format_bold("**one** and **two**")).toBe(
+    expect(format_markdown("**one** and **two**")).toBe(
       "<strong>one</strong> and <strong>two</strong>"
     );
   });
 
-  it("returns text unchanged when no bold markers present", () => {
-    expect(format_bold("plain text")).toBe("plain text");
+  it("converts *text* to <em>text</em>", () => {
+    expect(format_markdown("This is *italic* text")).toBe(
+      "This is <em>italic</em> text"
+    );
+  });
+
+  it("converts `code` to <code>code</code>", () => {
+    expect(format_markdown("Use `format_markdown` here")).toBe(
+      "Use <code>format_markdown</code> here"
+    );
+  });
+
+  it("converts [text](url) to an anchor tag", () => {
+    expect(format_markdown("[example](https://example.com)")).toBe(
+      '<a href="https://example.com">example</a>'
+    );
+  });
+
+  it("returns text unchanged when no markdown present", () => {
+    expect(format_markdown("plain text")).toBe("plain text");
   });
 });
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,10 +1,12 @@
+import { marked } from "marked";
+
 const MONTHS = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
-export function format_bold(text: string): string {
-  return text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+export function format_markdown(text: string): string {
+  return marked.parseInline(text) as string;
 }
 
 export function format_date(date_str: string): string {

--- a/src/lib/themes/classic/ClassicEmploymentEntry.svelte
+++ b/src/lib/themes/classic/ClassicEmploymentEntry.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Employment } from "$lib/types.js";
-  import { format_bold, format_date_range } from "$lib/format.js";
+  import { format_markdown, format_date_range } from "$lib/format.js";
 
   let { entry }: { entry: Employment } = $props();
 
@@ -19,11 +19,11 @@
   </div>
 
   {#if entry.description}
-    <p class="mt-2 text-sm leading-relaxed text-gray-600 italic">{entry.description.trim()}</p>
+    <p class="mt-2 text-sm leading-relaxed text-gray-600 italic">{@html format_markdown(entry.description.trim())}</p>
   {/if}
 
   {#if entry.summary}
-    <p class="mt-2 text-sm leading-relaxed text-gray-700">{entry.summary.trim()}</p>
+    <p class="mt-2 text-sm leading-relaxed text-gray-700">{@html format_markdown(entry.summary.trim())}</p>
   {/if}
 
   {#if entry.highlights.length > 0}
@@ -33,7 +33,7 @@
           {#if highlight.title}
             <span class="font-medium">{highlight.title}:</span>
           {/if}
-          {@html format_bold(highlight.description.trim())}
+          {@html format_markdown(highlight.description.trim())}
         </li>
       {/each}
     </ul>

--- a/src/lib/themes/classic/ClassicSummary.svelte
+++ b/src/lib/themes/classic/ClassicSummary.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { format_markdown } from "$lib/format.js";
+
   let { summary }: { summary: string } = $props();
 
   const paragraphs = $derived(summary.split("\n\n").filter((p) => p.trim()));
@@ -9,6 +11,6 @@
     Summary
   </h2>
   {#each paragraphs as paragraph}
-    <p class="mt-2 text-sm leading-relaxed text-gray-700">{paragraph.trim()}</p>
+    <p class="mt-2 text-sm leading-relaxed text-gray-700">{@html format_markdown(paragraph.trim())}</p>
   {/each}
 </section>

--- a/src/lib/themes/product-manual/ManualEmploymentEntry.svelte
+++ b/src/lib/themes/product-manual/ManualEmploymentEntry.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Employment } from "$lib/types.js";
-  import { format_bold, format_date_range } from "$lib/format.js";
+  import { format_markdown, format_date_range } from "$lib/format.js";
 
   let { entry }: { entry: Employment } = $props();
 
@@ -33,12 +33,12 @@
 
   {#if entry.description}
     <p class="mt-3 text-[11px] italic leading-relaxed text-stone-500">
-      {entry.description.trim()}
+      {@html format_markdown(entry.description.trim())}
     </p>
   {/if}
 
   {#if entry.summary}
-    <p class="mt-2 text-xs leading-relaxed text-stone-700">{entry.summary.trim()}</p>
+    <p class="mt-2 text-xs leading-relaxed text-stone-700">{@html format_markdown(entry.summary.trim())}</p>
   {/if}
 
   {#if entry.highlights.length > 0}
@@ -50,7 +50,7 @@
             {#if highlight.title}
               <span class="font-bold uppercase text-stone-500">{highlight.title}:</span>
             {/if}
-            {@html format_bold(highlight.description.trim())}
+            {@html format_markdown(highlight.description.trim())}
           </span>
         </li>
       {/each}

--- a/src/lib/themes/product-manual/ManualSummary.svelte
+++ b/src/lib/themes/product-manual/ManualSummary.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { format_markdown } from "$lib/format.js";
+
   let { summary }: { summary: string } = $props();
 
   const paragraphs = $derived(summary.split("\n\n").filter((p) => p.trim()));
@@ -11,6 +13,6 @@
     </h2>
   </div>
   {#each paragraphs as paragraph}
-    <p class="mt-2 text-xs leading-relaxed text-stone-700">{paragraph.trim()}</p>
+    <p class="mt-2 text-xs leading-relaxed text-stone-700">{@html format_markdown(paragraph.trim())}</p>
   {/each}
 </section>

--- a/src/lib/themes/retro-technical/RetroDomains.svelte
+++ b/src/lib/themes/retro-technical/RetroDomains.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Domain } from "$lib/types.js";
+  import { format_markdown } from "$lib/format.js";
 
   let { domains, section }: { domains: Domain[]; section: string } = $props();
 </script>
@@ -28,7 +29,7 @@
           {domain.title}
         </h3>
         <p class="mt-1 text-sm leading-relaxed text-[#1a2744]">
-          {domain.description.trim()}
+          {@html format_markdown(domain.description.trim())}
         </p>
       </div>
     {/each}

--- a/src/lib/themes/retro-technical/RetroEmploymentEntry.svelte
+++ b/src/lib/themes/retro-technical/RetroEmploymentEntry.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Employment } from "$lib/types.js";
-  import { format_bold, format_date_range } from "$lib/format.js";
+  import { format_markdown, format_date_range } from "$lib/format.js";
 
   let { entry, index }: { entry: Employment; index: number } = $props();
 
@@ -57,12 +57,12 @@
 
   {#if entry.description}
     <p class="my-3 border-t border-[#243555] py-3 text-base italic leading-relaxed text-[#8b9bb5] print:break-inside-avoid">
-      {entry.description.trim()}
+      {@html format_markdown(entry.description.trim())}
     </p>
   {/if}
 
   {#if entry.summary}
-    <p class="mt-2 text-base leading-relaxed text-[#f0e6d6] print:break-inside-avoid">{entry.summary.trim()}</p>
+    <p class="mt-2 text-base leading-relaxed text-[#f0e6d6] print:break-inside-avoid">{@html format_markdown(entry.summary.trim())}</p>
   {/if}
 
   {#if entry.highlights.length > 0}
@@ -76,7 +76,7 @@
             {#if highlight.title}
               <span class="font-semibold uppercase text-[#8b9bb5]" style="font-family: var(--retro-heading-font);">{highlight.title}:</span>
             {/if}
-            {@html format_bold(highlight.description.trim())}
+            {@html format_markdown(highlight.description.trim())}
           </span>
         </li>
       {/each}

--- a/src/lib/themes/retro-technical/RetroSummary.svelte
+++ b/src/lib/themes/retro-technical/RetroSummary.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { format_bold } from "$lib/format.js";
+  import { format_markdown } from "$lib/format.js";
 
   let { summary, section, tagline }: { summary: string; section: string; tagline?: string } = $props();
 
@@ -24,12 +24,12 @@
   </div>
 
   {#each paragraphs as paragraph}
-    <p class="mt-2 first:mt-0 text-base leading-relaxed text-[#1a2744]">{@html format_bold(paragraph.trim())}</p>
+    <p class="mt-2 first:mt-0 text-base leading-relaxed text-[#1a2744]">{@html format_markdown(paragraph.trim())}</p>
   {/each}
 
   {#if tagline}
     <div class="mt-4 border-t border-[#c96620]/30 pt-3">
-      <p class="text-base leading-relaxed text-[#1a2744]/80">{@html format_bold(tagline.trim())}</p>
+      <p class="text-base leading-relaxed text-[#1a2744]/80">{@html format_markdown(tagline.trim())}</p>
     </div>
   {/if}
 </section>


### PR DESCRIPTION
## Summary

- Replaces the regex-only `format_bold()` with `marked.parseInline()` via the `marked` library, enabling bold, italic, links, and inline code rendering
- Adds markdown rendering to employment description/summary fields and domain descriptions that were previously plain text across all three themes
- Updates tests to cover the full range of inline markdown syntax

## Test plan

- [x] `npm test` — all 30 tests pass (6 new format_markdown tests replace 3 old format_bold tests)
- [x] `npm run build` — clean production build, no type errors
- [ ] Preview cto-a variant — verify bold/italic renders in summary, tagline, employment descriptions, highlights, and domain descriptions
- [ ] Preview default variant — verify classic theme renders markdown correctly
- [ ] Preview product-manual variant — verify markdown renders correctly

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)