### PR TITLE
Bump OG card text sizes and uppercase name

### DIFF
--- a/src/routes/og/[variant=variant]/+page.svelte
+++ b/src/routes/og/[variant=variant]/+page.svelte
@@ -64,21 +64,23 @@
   }
 
   .name {
-    font-size: 52px;
+    font-size: 80px;
     font-weight: 700;
-    margin: 0 0 20px 0;
+    margin: 0 0 24px 0;
     line-height: 1.1;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
   }
 
   .divider {
-    width: 80px;
-    height: 4px;
-    margin-bottom: 20px;
+    width: 120px;
+    height: 6px;
+    margin-bottom: 24px;
     border-radius: 2px;
   }
 
   .title {
-    font-size: 30px;
+    font-size: 44px;
     font-weight: 500;
     margin: 0;
     line-height: 1.2;


### PR DESCRIPTION
## Summary
- Increased `.name` font-size from 52px to 80px and made it uppercase with slight letter-spacing
- Increased `.title` font-size from 30px to 44px
- Scaled divider from 80×4px to 120×6px with proportional margin bumps

Closes #63

## Test plan
- [ ] `npm run build` passes
- [ ] Visit `/og/default` and `/og/cto-a` in preview to confirm larger, bolder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)