### PR TITLE
Fix broken README badges (version, CI, license)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,21 @@
-This repository is licensed under the MIT License for all code, scripts, and styling.
+MIT License
 
-HOWEVER, all personal content, including but not limited to the text (Operational Logs, Executive Summary), images, and the "Tim Gunter" brand, is © 2026 Tim Gunter. All Rights Reserved. > You are free to use the code as a template, but you must replace all personal information and assets with your own.
+Copyright (c) 2026 Tim Gunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+NOTICE
+
+The MIT License applies to all code, scripts, configuration, and styling in
+this repository.
+
+All personal content, including but not limited to the text, images, and the
+"Tim Gunter" brand, is (c) 2026 Tim Gunter. All Rights Reserved. You are free
+to use the code as a template, but you must replace all personal information
+and assets with your own.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Resume
 
-![Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkaecyra%2Fresume%2Fmain%2FVERSION&search=%5E.*%24&label=version)
+![Version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkaecyra%2Fresume%2Fmain%2FVERSION&search=%5B%5Cd.%5D%2B&label=version)
 ![CI](https://github.com/kaecyra/resume/actions/workflows/ci.yml/badge.svg?branch=main)
 ![Node](https://img.shields.io/badge/node-%3E%3D24-339933?logo=node.js&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-ready-2496ED?logo=docker&logoColor=white)
@@ -78,7 +78,7 @@ Resume content lives in `data/resume.yaml` as a single source of truth containin
 
 ## CI
 
-GitHub Actions runs on pull requests to `main`, executing type checking, tests, and a production build in sequence. See [ENGINEERING.md](./ENGINEERING.md) for full coding standards and CI requirements.
+GitHub Actions runs on pushes and pull requests to `main`, executing type checking, tests, and a production build in sequence. See [ENGINEERING.md](./ENGINEERING.md) for full coding standards and CI requirements.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

- **Version badge**: Fix regex from `^.*$` to `[\d.]+` — trailing newline in VERSION file caused shields.io to return no match
- **CI badge**: Add `push: branches: [main]` trigger — PR-triggered runs aren't associated with main, so the badge had no runs to report
- **License badge**: Replace custom LICENSE with standard MIT text so GitHub's license API detects it; move personal content restriction to NOTICE file

Closes #77

## Test plan

- [ ] Verify version badge renders at shields.io URL with new regex (confirmed locally via WebFetch)
- [ ] Verify license badge renders after GitHub re-detects the license (may take a few minutes)
- [ ] CI badge will show status after first push/merge to main with the new trigger
- [ ] `npm test` passes (37/37)
- [ ] `npm run check` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)