### PR TITLE
Change employment vitals background color

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -4,6 +4,7 @@
 
 @theme {
   --color-retro-navy: #1a2744;
+  --color-retro-navy-deep: #1b2b39;
   --color-retro-navy-light: #243555;
   --color-retro-accent: #e87a2e;
   --color-retro-accent-dark: #c96620;

--- a/src/lib/themes/retro-technical/RetroEmploymentEntry.svelte
+++ b/src/lib/themes/retro-technical/RetroEmploymentEntry.svelte
@@ -17,7 +17,7 @@
 </style>
 
 <div class="mt-6">
-  <div class="-mx-4 md:-mx-6 print:-mx-6 bg-retro-navy px-4 py-4 md:px-6 md:py-5 print:px-6 print:py-5 print:break-inside-avoid">
+  <div class="-mx-4 md:-mx-6 print:-mx-6 bg-retro-navy-deep px-4 py-4 md:px-6 md:py-5 print:px-6 print:py-5 print:break-inside-avoid">
     <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between md:gap-4">
       <div class="min-w-0">
         <div class="grid grid-cols-[auto_1fr] items-baseline gap-x-3 gap-y-1.5">


### PR DESCRIPTION
## Summary

- Adds `retro-navy-deep` (`#1b2b39`) palette entry
- Applies it to the employment row vitals background in the retro-technical theme

## Test plan

- [x] `npm run check` passes
- [ ] Visual check: employment vitals row uses new background color

🤖 Generated with [Claude Code](https://claude.com/claude-code)