### PR TITLE
Fix analytics 404 by proxying to Umami default script path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
     environment:
       DATABASE_URL: postgresql://umami:${POSTGRES_PASSWORD:?}@umami_db:5432/umami
       APP_SECRET: ${UMAMI_APP_SECRET:?}
-      TRACKER_SCRIPT_NAME: insights
     depends_on:
       umami_db:
         condition: service_healthy

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,7 +22,7 @@ server {
     set $umami http://umami:3000;
 
     location = /insights.js {
-        proxy_pass $umami/insights.js;
+        proxy_pass $umami/script.js;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -284,7 +284,6 @@ services:
     environment:
       DATABASE_URL: postgresql://umami:${POSTGRES_PASSWORD:?}@umami_db:5432/umami
       APP_SECRET: ${UMAMI_APP_SECRET:?}
-      TRACKER_SCRIPT_NAME: insights
     depends_on:
       umami_db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- `TRACKER_SCRIPT_NAME` doesn't work with the pre-built Umami Docker image (Next.js generates the script at build time)
- Fix: nginx proxies `/insights.js` to Umami's default `/script.js` — the rename happens at the proxy layer
- Removes unused `TRACKER_SCRIPT_NAME` env var from both compose files

## Test plan

- [ ] Deploy and verify `/insights.js` returns the Umami tracker script (not 404)
- [ ] Verify pageview events reach Umami dashboard via `/api/send`

🤖 Generated with [Claude Code](https://claude.com/claude-code)