### PR TITLE
Fix 404 on trailing slash URLs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Strip trailing slashes (except root) - SvelteKit generates .html files, not index.html
+    rewrite ^(.+)/$ $1 permanent;
+
     # All other routes - prerendered HTML pages
     location / {
         try_files $uri $uri.html $uri/ =404;


### PR DESCRIPTION
## Summary

URLs with trailing slashes (e.g. `/cto-a/`) return 404 in production. SvelteKit's static adapter generates `cto-a.html` files, but nginx's `try_files $uri $uri.html $uri/` resolves `/cto-a/` to `/cto-a/.html` which doesn't exist.

Adds a `rewrite ^(.+)/$ $1 permanent` rule to strip trailing slashes with a 301 redirect before `try_files` runs.

## Test plan

- [ ] `/cto-a/` redirects to `/cto-a` and loads
- [ ] `/cto-a/62e07c5c/` redirects to `/cto-a/62e07c5c` and loads
- [ ] `/cto-a/62e07c5c/letter/` redirects to `/cto-a/62e07c5c/letter` and loads
- [ ] `/cto-a` continues to work without redirect
- [ ] `/` (root) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)