### PR TITLE
Add script tag to AiDisclosure for svelte-check

### DIFF
--- a/src/lib/components/AiDisclosure.svelte
+++ b/src/lib/components/AiDisclosure.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="mt-8 rounded border border-gray-200 bg-gray-50 px-4 py-3 text-xs leading-relaxed text-gray-400 print:bg-gray-50">
   <p>
     This cover letter was created with assistance from AI, as part of an ongoing experiment with


### PR DESCRIPTION
## Summary
- AiDisclosure.svelte was missing a `<script lang="ts">` block, causing `svelte-check` to fail with "implicitly has an 'any' type" on all three cover letter imports

## Test plan
- [ ] `npm run check` passes
- [ ] `npm test` passes