### PR TITLE
Enable TypeScript LSP plugin for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,5 +30,8 @@
       "Bash(chmod:*)",
       "WebSearch"
     ]
+  },
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Enable the `typescript-lsp` plugin in `.claude/settings.json` for in-editor type diagnostics

Closes #116