### PR TITLE
Fix dashboard auth: use htpasswd instead of openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN (npm run preview &) && sleep 2 && npm run generate-og && npm run generate-pd
 
 FROM nginx:stable-alpine
 
+RUN apk add --no-cache apache2-utils
+
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/build /usr/share/nginx/html
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 if [ -n "$DASHBOARD_USER" ] && [ -n "$DASHBOARD_PASSWORD" ]; then
-    HASHED=$(openssl passwd -apr1 "$DASHBOARD_PASSWORD")
-    echo "${DASHBOARD_USER}:${HASHED}" > /etc/nginx/.htpasswd
+    htpasswd -cb /etc/nginx/.htpasswd "$DASHBOARD_USER" "$DASHBOARD_PASSWORD"
 else
     : > /etc/nginx/.htpasswd
 fi


### PR DESCRIPTION
## Summary

- `openssl` isn't available in `nginx:stable-alpine`, so the entrypoint was generating an empty password hash
- Installs `apache2-utils` and uses `htpasswd -cb` instead, which is the right tool for the job

## Test plan

- [ ] Docker build succeeds
- [ ] With `DASHBOARD_USER`/`DASHBOARD_PASSWORD` set, `/variants` prompts for Basic auth and accepts the credentials
- [ ] Without credentials set, `/variants` returns 401