### PR TITLE
Fix analytics API proxy routing and unconfigured fallback

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 if [ -n "$UMAMI_API_TOKEN" ]; then
     printf 'proxy_set_header Authorization "Bearer %s";\n' "$UMAMI_API_TOKEN" > /etc/nginx/umami_auth.conf
 else
-    printf '# UMAMI_API_TOKEN not set\n' > /etc/nginx/umami_auth.conf
+    printf 'return 503;\n' > /etc/nginx/umami_auth.conf
 fi
 
 exec nginx -g 'daemon off;'

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,7 +42,8 @@ server {
         auth_basic "Restricted";
         auth_basic_user_file /etc/nginx/.htpasswd;
         include /etc/nginx/umami_auth.conf;
-        proxy_pass $umami/api/;
+        rewrite ^/api/umami/(.*) /api/$1 break;
+        proxy_pass $umami;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

- Adds `rewrite` rule to strip `/api/umami/` prefix before proxying — nginx skips automatic URI rewriting when `proxy_pass` uses a variable, causing requests to hit `umami:3000/api/umami/...` instead of `umami:3000/api/...`
- Returns 503 immediately when `UMAMI_API_TOKEN` is unset instead of proxying unauthenticated requests through to Umami

## Test plan

- [ ] Deploy with `UMAMI_API_TOKEN` set, verify metrics load on `/variants` (no console errors)
- [ ] Deploy without `UMAMI_API_TOKEN`, verify 503 (not 404) and em-dashes in UI

Closes #132