### PR TITLE
Fix Puppeteer screenshot crash in Docker build

### DIFF
--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -18,7 +18,7 @@ async function generate_og_images(): Promise<void> {
 
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
 
   try {

--- a/scripts/generate-pdf.ts
+++ b/scripts/generate-pdf.ts
@@ -95,7 +95,7 @@ async function generate_pdf(): Promise<void> {
 
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
 
   try {


### PR DESCRIPTION
## Summary
- Add `--disable-dev-shm-usage` and `--disable-gpu` to Chromium launch args in both Puppeteer scripts
- Docker `RUN` steps default to 64MB `/dev/shm`; Chromium's `Page.captureScreenshot` exceeds that during frame bitmap transfer, crashing the renderer with "Protocol error: Internal error"
- This was blocking the retro-clean theme deploy since 2026-03-20 (5 prior fix attempts addressed timeouts and external requests, but not the shared memory constraint)

## Test plan
- [ ] CI build passes (Docker image builds successfully)
- [ ] OG images generated for all variants
- [ ] PDFs generated for all variants and sub-variants
- [ ] Deployed site shows retro-clean theme at resume.timgunter.ca